### PR TITLE
Use time.time() for Python 3.8+ compatibility

### DIFF
--- a/game_engine_save_as_runtime_eevee.py
+++ b/game_engine_save_as_runtime_eevee.py
@@ -304,7 +304,7 @@ class SaveAsRuntime(bpy.types.Operator):
 
     def execute(self, context):
         import time
-        start_time = time.clock()
+        start_time = time.time()
         print("Saving runtime to %r" % self.filepath)
         WriteRuntime(self.player_path,
                      self.filepath,
@@ -317,7 +317,7 @@ class SaveAsRuntime(bpy.types.Operator):
                      self.copy_modules,
                      self.report,
                      )
-        print("Finished in %.4fs" % (time.clock()-start_time))
+        print("Finished in %.4fs" % (time.time()-start_time))
         return {'FINISHED'}
 
     def invoke(self, context, event):


### PR DESCRIPTION
`time.clock()` was removed in Python 3.8.

See: https://docs.python.org/3.7/library/time.html#time.clock